### PR TITLE
Preserve selection and cursor position when component receives new value prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ React.render(
 |showGutter| boolean|
 |showPrintMargin| boolean|
 |highlightActiveLine| boolean|
+|selectFirstLine| boolean|
 |readOnly| boolean|
 |maxLines| Maximum number of lines to be displayed|
 |defaultValue | String value you want to populate in the code highlighter upon creation|

--- a/src/ace.js
+++ b/src/ace.js
@@ -19,7 +19,8 @@ const AceEditor = React.createClass({
         maxLines: React.PropTypes.number,
         readOnly: React.PropTypes.bool,
         highlightActiveLine: React.PropTypes.bool,
-        showPrintMargin: React.PropTypes.bool
+        showPrintMargin: React.PropTypes.bool,
+        selectFirstLine: React.PropTypes.bool
     },
     getDefaultProps() {
         return {

--- a/src/ace.js
+++ b/src/ace.js
@@ -37,7 +37,8 @@ const AceEditor = React.createClass({
             maxLines: null,
             readOnly: false,
             highlightActiveLine: true,
-            showPrintMargin: true
+            showPrintMargin: true,
+            selectFirstLine: false
         };
     },
     onChange() {
@@ -52,7 +53,7 @@ const AceEditor = React.createClass({
         this.editor.setTheme('ace/theme/' + this.props.theme);
         this.editor.setFontSize(this.props.fontSize);
         this.editor.on('change', this.onChange);
-        this.editor.setValue(this.props.defaultValue || this.props.value, -1);
+        this.editor.setValue(this.props.defaultValue || this.props.value, (this.props.selectFirstLine === true ? -1 : null));
         this.editor.setOption('maxLines', this.props.maxLines);
         this.editor.setOption('readOnly', this.props.readOnly);
         this.editor.setOption('highlightActiveLine', this.props.highlightActiveLine);
@@ -65,7 +66,7 @@ const AceEditor = React.createClass({
     },
 
     componentWillReceiveProps(nextProps) {
-        let cursorPosition = this._getCurrentCursorPosition();
+        let currentRange = this.editor.selection.getRange();
 
         // only update props if they are changed
         if (nextProps.mode !== this.props.mode) {
@@ -90,21 +91,13 @@ const AceEditor = React.createClass({
             this.editor.setShowPrintMargin(nextProps.setShowPrintMargin);
         }
         if (nextProps.value && this.editor.getValue() !== nextProps.value) {
-            this.editor.setValue(nextProps.value, -1);
-            if(cursorPosition && typeof cursorPosition === "object") {
-                this.editor.getSession().getSelection().selectionLead.setPosition(cursorPosition.row, cursorPosition.column);
+            this.editor.setValue(nextProps.value, (this.props.selectFirstLine === true ? -1 : null));
+            if(currentRange && typeof currentRange === "object") {
+                this.editor.getSession().getSelection().setSelectionRange(currentRange);
             }
         }
         if (nextProps.showGutter !== this.props.showGutter) {
             this.editor.renderer.setShowGutter(nextProps.showGutter);
-        }
-    },
-
-    _getCurrentCursorPosition() {
-        let pos = this.editor.selection.getCursor() || {};
-        return {
-          row: pos.row || 0,
-          column: pos.column || 0
         }
     },
 

--- a/src/ace.js
+++ b/src/ace.js
@@ -52,7 +52,7 @@ const AceEditor = React.createClass({
         this.editor.setTheme('ace/theme/' + this.props.theme);
         this.editor.setFontSize(this.props.fontSize);
         this.editor.on('change', this.onChange);
-        this.editor.setValue(this.props.defaultValue || this.props.value);
+        this.editor.setValue(this.props.defaultValue || this.props.value, -1);
         this.editor.setOption('maxLines', this.props.maxLines);
         this.editor.setOption('readOnly', this.props.readOnly);
         this.editor.setOption('highlightActiveLine', this.props.highlightActiveLine);
@@ -65,6 +65,8 @@ const AceEditor = React.createClass({
     },
 
     componentWillReceiveProps(nextProps) {
+        let cursorPosition = this._getCurrentCursorPosition();
+
         // only update props if they are changed
         if (nextProps.mode !== this.props.mode) {
             this.editor.getSession().setMode('ace/mode/' + nextProps.mode);
@@ -88,10 +90,21 @@ const AceEditor = React.createClass({
             this.editor.setShowPrintMargin(nextProps.setShowPrintMargin);
         }
         if (nextProps.value && this.editor.getValue() !== nextProps.value) {
-            this.editor.setValue(nextProps.value);
+            this.editor.setValue(nextProps.value, -1);
+            if(cursorPosition && typeof cursorPosition === "object") {
+                this.editor.getSession().getSelection().selectionLead.setPosition(cursorPosition.row, cursorPosition.column);
+            }
         }
         if (nextProps.showGutter !== this.props.showGutter) {
             this.editor.renderer.setShowGutter(nextProps.showGutter);
+        }
+    },
+
+    _getCurrentCursorPosition() {
+        let pos = this.editor.selection.getCursor() || {};
+        return {
+          row: pos.row || 0,
+          column: pos.column || 0
         }
     },
 


### PR DESCRIPTION
Pull request with couple of improvements:
- Preserve selected range when component will receive a new updated value
- Added prop selectFirstLine which defaults to false. If prop is true, the cursor will be moved to first line on the editor. Given false, Ace's default functionality will kick in and all text will be selected.
